### PR TITLE
Fix: Add Travis CI and Code Climate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # api-output
+
+[![Build Status](https://travis-ci.org/refinery29/api-output.svg?branch=master)](https://travis-ci.org/refinery29/api-output)
+[![Code Climate](https://codeclimate.com/github/refinery29/api-output/badges/gpa.svg)](https://codeclimate.com/github/refinery29/api-output)
+[![Test Coverage](https://codeclimate.com/github/refinery29/api-output/badges/coverage.svg)](https://codeclimate.com/github/refinery29/api-output/coverage)
+
 Package for generating API output per refinery29/api-standards


### PR DESCRIPTION
This PR

* [x] adds Travis CI and Code Climate badges

:information_desk_person: Will follow up with a PR that fixes Code Climate integration.