### PR TITLE
Fix: Do not build twice against PHP5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 matrix:
   include:
     - php: 5.5
-    - php: 5.5
+    - php: 5.6
       env: COLLECT_COVERAGE=true
 
 cache:


### PR DESCRIPTION
This PR

* [x] fixes the build matrix defined in `.travis.yml`, as currently, two builds are run against PHP 5.5, while probably, the second build should be run against PHP5.6 instead