### PR TITLE
Fix: Also run build against PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - php: 5.5
     - php: 5.6
       env: COLLECT_COVERAGE=true
+    - php: 7
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
+  - if [ "$TRAVIS_PHP_VERSION" == "7" ]; then mv -v phpspec.php7.yml phpspec.yml; fi
 
 script:
   - bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run

--- a/phpspec.php7.yml
+++ b/phpspec.php7.yml
@@ -1,0 +1,4 @@
+suites:
+  ion:
+    namespace: Refinery29\ApiOutput
+    psr4_prefix: Refinery29\ApiOutput


### PR DESCRIPTION
This PR

* [x] adds PHP7 to the build matrix
* [x] adds a `phpspec.no-coverage.yml` and overwrites `phpspec.yml` when on PHP7

Related to #5.