### PR TITLE
Fix: Ignore bin, build, coverage directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-/vendor/
-.idea/*
+.idea
+/bin
+/build
+/coverage
+/vendor


### PR DESCRIPTION
This PR

* [x] ignores the `bin`, `build`, and `coverage` directories which are created when you install dependencies and run the tests