### PR TITLE
Fix: Method returns LinkCollection, not an array

### DIFF
--- a/src/Resource/Error/Error.php
+++ b/src/Resource/Error/Error.php
@@ -103,7 +103,7 @@ class Error implements HasSerializer
     }
 
     /**
-     * @return array
+     * @return LinkCollection
      */
     public function getLinks()
     {


### PR DESCRIPTION
This PR

* [x] fixes a docblock