### PR TITLE
Fix: Move interface into Resource namespace

### DIFF
--- a/src/Resource/TopLevelResource.php
+++ b/src/Resource/TopLevelResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Refinery29\ApiOutput;
+namespace Refinery29\ApiOutput\Resource;
 
 interface TopLevelResource
 {

--- a/src/Serializer/Error/ErrorCollection.php
+++ b/src/Serializer/Error/ErrorCollection.php
@@ -2,9 +2,9 @@
 
 namespace Refinery29\ApiOutput\Serializer\Error;
 
+use Refinery29\ApiOutput\Resource\TopLevelResource;
 use Refinery29\ApiOutput\Serializer\HasSerializer;
 use Refinery29\ApiOutput\Serializer\Serializer;
-use Refinery29\ApiOutput\TopLevelResource;
 
 class ErrorCollection implements Serializer, TopLevelResource
 {

--- a/src/Serializer/Link/LinkCollection.php
+++ b/src/Serializer/Link/LinkCollection.php
@@ -5,9 +5,9 @@ namespace Refinery29\ApiOutput\Serializer\Link;
 use Exception;
 use Refinery29\ApiOutput\Resource\Link\Link;
 use Refinery29\ApiOutput\Resource\Link\LinkCollection as Input;
+use Refinery29\ApiOutput\Resource\TopLevelResource;
 use Refinery29\ApiOutput\Serializer\HasSerializer;
 use Refinery29\ApiOutput\Serializer\Serializer;
-use Refinery29\ApiOutput\TopLevelResource;
 
 class LinkCollection implements Serializer, TopLevelResource
 {

--- a/src/Serializer/Pagination/Pagination.php
+++ b/src/Serializer/Pagination/Pagination.php
@@ -4,9 +4,9 @@ namespace Refinery29\ApiOutput\Serializer\Pagination;
 
 use Refinery29\ApiOutput\Resource\Link\Link;
 use Refinery29\ApiOutput\Resource\Pagination\Pagination as Input;
+use Refinery29\ApiOutput\Resource\TopLevelResource;
 use Refinery29\ApiOutput\Serializer\HasSerializer;
 use Refinery29\ApiOutput\Serializer\Serializer;
-use Refinery29\ApiOutput\TopLevelResource;
 
 class Pagination implements TopLevelResource, Serializer
 {

--- a/src/Serializer/Result.php
+++ b/src/Serializer/Result.php
@@ -3,7 +3,7 @@
 namespace Refinery29\ApiOutput\Serializer;
 
 use Refinery29\ApiOutput\Resource\Result as Input;
-use Refinery29\ApiOutput\TopLevelResource;
+use Refinery29\ApiOutput\Resource\TopLevelResource;
 
 class Result implements Serializer, TopLevelResource
 {


### PR DESCRIPTION
This PR

* [x] moves the `TopLevelResource` interface into `Refinery29\ApiOutput\Resource`

:information_desk_person: Feels like this should be its home, shouldn't it?