### PR TITLE
Fix: Ignore .php_cs.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build
 /coverage
 /vendor
+.php_cs.cache


### PR DESCRIPTION
This PR

* [x] adds the `php-cs-fixer` cache file to `.gitignore`