### PR TITLE
Fix: Drop PHP 5.5 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 matrix:
   include:
-    - php: 5.5
     - php: 5.6
       env: COLLECT_COVERAGE=true
 


### PR DESCRIPTION
This PR

* [x] drops PHP 5.5 from the build matrix

💁‍♂️ For reference, see http://php.net/supported-versions.php.