### PR TITLE
Fix: Also validate composer.json in composer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 composer:
+	composer validate
 	composer install
 
 cs: composer


### PR DESCRIPTION
This PR

* [x] also validates `composer.json` and `composer.lock` in `composer` of `Makefile` target