### PR TITLE
Fix: Keep composer itself updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 composer:
+	composer self-update
 	composer validate
 	composer install
 


### PR DESCRIPTION
This PR

* [x] keeps `composer` itself updated in `composer` target of `Makefile`