### PR TITLE
Fix: Disable and enable xdebug only when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
+  - source .travis/xdebug.sh
+  - xdebug-disable
   - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
@@ -30,7 +32,9 @@ before_script:
 
 script:
   - bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
+  - xdebug-enable
   - bin/phpspec run --format=dot
+  - xdebug-disable
 
 after_script:
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$COLLECT_COVERAGE" == "true" ]]; then bin/test-reporter; fi

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# The problem is that we do not want to remove the configuration file, just disable it for a few tasks, then enable it
+#
+# For reference, see
+#
+# - https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions
+# - https://docs.travis-ci.com/user/languages/php#Custom-PHP-configuration
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+function xdebug-disable() {
+    if [[ -f $config ]]; then
+        mv $config "$config.bak"
+    fi
+}
+
+function xdebug-enable() {
+    if [[ -f "$config.bak" ]]; then
+        mv "$config.bak" $config
+    fi
+}


### PR DESCRIPTION
This PR

* [x] disables and enables xdebug only when it is needed