### PR TITLE
Enhancement: Add PHP 7.0 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
 matrix:
   include:
     - php: 5.6
+      env: WITH_CS=true
+    - php: 7.0
 
 cache:
   directories:
@@ -30,7 +32,7 @@ before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
 
 script:
-  - bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
+  - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose; fi
   - bin/phpspec run --format=dot
 
 notifications:

--- a/spec/ResponseBodySpec.php
+++ b/spec/ResponseBodySpec.php
@@ -12,7 +12,6 @@ use Refinery29\ApiOutput\Serializer\Error\ErrorCollection;
 use Refinery29\ApiOutput\Serializer\Link\LinkCollection as Serializer;
 use Refinery29\ApiOutput\Serializer\Pagination\Pagination;
 use Refinery29\ApiOutput\Serializer\Result;
-use Refinery29\ApiOutput\Serializer\Serializer as Generic;
 
 class ResponseBodySpec extends ObjectBehavior
 {
@@ -152,10 +151,5 @@ class ResponseBodySpec extends ObjectBehavior
         $serializer->getTopLevelName()->willReturn('pagination');
 
         $this->getOutput()->shouldReturn('{"pagination":{"first":"http://yolo.com","last":"http://yolo.com"}}');
-    }
-
-    public function it_can_only_add_top_level_members(Generic $serializer)
-    {
-        $this->shouldThrow(\Exception::class)->during('addMember', [$serializer]);
     }
 }

--- a/spec/Serializer/Error/ErrorSpec.php
+++ b/spec/Serializer/Error/ErrorSpec.php
@@ -10,7 +10,9 @@ class ErrorSpec extends ObjectBehavior
 {
     public function it_must_pass_error()
     {
-        $this->shouldThrow(\Exception::class)->duringInstantiation(new LinkCollection());
+        $this->beConstructedWith(new LinkCollection());
+
+        $this->shouldThrow(\Exception::class)->duringInstantiation();
     }
 
     public function it_can_get_default_output()

--- a/spec/Serializer/Link/LinkCollectionSpec.php
+++ b/spec/Serializer/Link/LinkCollectionSpec.php
@@ -39,11 +39,6 @@ class LinkCollectionSpec extends ObjectBehavior
         $this->getOutput()->shouldObjectMatch($output);
     }
 
-    public function it_must_pass_link_collection()
-    {
-        $this->shouldThrow(\Exception::class)->duringInstantiation(Link::createFirst('http'));
-    }
-
     public function it_can_get_top_level_name()
     {
         $this->beConstructedWith(new LinkCollection());

--- a/src/ResponseBody.php
+++ b/src/ResponseBody.php
@@ -13,11 +13,6 @@ class ResponseBody
      */
     protected $members = [];
 
-    /**
-     * @param TopLevelResource $member
-     *
-     * @throws \Exception
-     */
     public function addMember(TopLevelResource $member)
     {
         $this->members[] = $member;


### PR DESCRIPTION
This PR

* [x] adds PHP 7.0 to the Travis build matrix
* [x] removes invalid specifications