### PR TITLE
Fix: Add it as first target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: composer cs test
+.PHONY: composer cs it test
+
+it: cs test
 
 composer:
 	composer self-update


### PR DESCRIPTION
This PR

* [x] adds `it` as first target in `Makefile`

💁‍♂️ Otherwise we can't run

```
$ make
```

to run coding standard checks and tests (as advertised in [`.github/CONTRIBUTING.md`](https://github.com/refinery29/api-output/blob/056a44e768299bc94027892505bc330734558409/.github/CONTRIBUTING.md)