### PR TITLE
Fix: Remove codeclimate/php-test-reporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "php": "^5.6 || ^7.0"
   },
   "require-dev": {
-    "codeclimate/php-test-reporter": "^0.2.0",
     "phpspec/phpspec": "^3.3.0",
     "refinery29/php-cs-fixer-config": "0.5.5"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,67 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "61ff47ae9690ec0f98a82c3e0e855bad",
+    "content-hash": "2c4c11aafe7e0212ae8ff7a1282a383a",
     "packages": [],
     "packages-dev": [
-        {
-            "name": "codeclimate/php-test-reporter",
-            "version": "v0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/codeclimate/php-test-reporter.git",
-                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/85b5de950678a25f3e85adb6bc26de7f7f231d18",
-                "reference": "85b5de950678a25f3e85adb6bc26de7f7f231d18",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "php": ">=5.3",
-                "satooshi/php-coveralls": "0.6.*",
-                "symfony/console": ">=2.0"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "phpunit/phpunit": "3.7.*@stable"
-            },
-            "bin": [
-                "composer/bin/test-reporter"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "CodeClimate\\Component": "src/",
-                    "CodeClimate\\Bundle": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Code Climate",
-                    "email": "hello@codeclimate.com",
-                    "homepage": "https://codeclimate.com"
-                }
-            ],
-            "description": "PHP client for reporting test coverage to Code Climate",
-            "homepage": "https://github.com/codeclimate/php-test-reporter",
-            "keywords": [
-                "codeclimate",
-                "coverage"
-            ],
-            "time": "2015-09-08T14:22:33+00:00"
-        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",


### PR DESCRIPTION
This PR

* [x] removes `codeclimate/php-test-reporter`

Follows #42.