### PR TITLE
Enhancement: Add PHP 7.1 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - php: 5.6
       env: WITH_CS=true
     - php: 7.0
+    - php: 7.1
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 to the Travis build matrix

Follows #44.